### PR TITLE
Rename Osc.Osc_types to Osc.Types

### DIFF
--- a/src/core/osc.ml
+++ b/src/core/osc.ml
@@ -1,4 +1,4 @@
-module Osc_types = struct
+module Types = struct
   include Osc_types
 end
 

--- a/src/core/osc.mli
+++ b/src/core/osc.mli
@@ -1,6 +1,6 @@
 (** IO-independent code for handling OSC packets and bundles. *)
 
-module Osc_types : sig
+module Types : sig
   (** Types representing OSC packets. *)
 
   type time = {
@@ -60,12 +60,12 @@ end
 module Codec : sig
   (** Conversion of OSC packets to and from strings. *)
 
-  val of_packet : Osc_types.packet -> string
+  val of_packet : Types.packet -> string
   (** Serialise an OSC packet into a string. *)
 
   val to_packet :
     string ->
-    (Osc_types.packet, [
+    (Types.packet, [
       | `Missing_typetag_string
       | `Unsupported_typetag of char
     ]) Result.t
@@ -144,7 +144,7 @@ module Transport : sig
       val destroy : t -> unit T.Io.t
       (** Destroy an OSC client. *)
 
-      val send : t -> T.sockaddr -> Osc_types.packet -> unit T.Io.t
+      val send : t -> T.sockaddr -> Types.packet -> unit T.Io.t
       (** [send client addr packet] uses [client] to send OSC packet [packet] to
           a server listening at address [addr]. *)
     end
@@ -165,7 +165,7 @@ module Transport : sig
 
       val recv :
         t ->
-        ((Osc_types.packet * T.sockaddr, [
+        ((Types.packet * T.sockaddr, [
           | `Missing_typetag_string
           | `Unsupported_typetag of char
         ]) Result.t) T.Io.t

--- a/src/lwt/osc_lwt.mli
+++ b/src/lwt/osc_lwt.mli
@@ -6,7 +6,7 @@ module Udp : sig
 
     val destroy : t -> unit Lwt.t
 
-    val send : t -> Lwt_unix.sockaddr -> Osc.Osc_types.packet -> unit Lwt.t
+    val send : t -> Lwt_unix.sockaddr -> Osc.Types.packet -> unit Lwt.t
   end
 
   module Server : sig
@@ -18,7 +18,7 @@ module Udp : sig
 
     val recv :
       t ->
-      ((Osc.Osc_types.packet * Lwt_unix.sockaddr, [
+      ((Osc.Types.packet * Lwt_unix.sockaddr, [
         | `Missing_typetag_string
         | `Unsupported_typetag of char
       ]) Result.result) Lwt.t

--- a/src/unix/osc_unix.mli
+++ b/src/unix/osc_unix.mli
@@ -6,7 +6,7 @@ module Udp : sig
 
     val destroy : t -> unit
 
-    val send : t -> Unix.sockaddr -> Osc.Osc_types.packet -> unit
+    val send : t -> Unix.sockaddr -> Osc.Types.packet -> unit
   end
 
   module Server : sig
@@ -18,7 +18,7 @@ module Udp : sig
 
     val recv :
       t ->
-      (Osc.Osc_types.packet * Unix.sockaddr, [
+      (Osc.Types.packet * Unix.sockaddr, [
         | `Missing_typetag_string
         | `Unsupported_typetag of char
       ]) Result.t

--- a/test/common/test_common.ml
+++ b/test/common/test_common.ml
@@ -1,19 +1,18 @@
-open Osc
 open OUnit
 
-let message_no_args = Osc_types.(Message {
+let message_no_args = Osc.Types.(Message {
   address = "/test";
   arguments = [];
 })
 
-let message_empty_string_arg = Osc_types.(Message {
+let message_empty_string_arg = Osc.Types.(Message {
   address = "/test";
   arguments = [
     String "";
   ];
 })
 
-let message_all_args_basic = Osc_types.(Message {
+let message_all_args_basic = Osc.Types.(Message {
   address = "/test";
   arguments = [
     String "foobar";
@@ -22,28 +21,28 @@ let message_all_args_basic = Osc_types.(Message {
   ];
 })
 
-let message_empty_blob_arg = Osc_types.(Message {
+let message_empty_blob_arg = Osc.Types.(Message {
   address = "/test";
   arguments = [
     Blob "";
   ];
 })
 
-let message_timetag_immediate_arg = Osc_types.(Message {
+let message_timetag_immediate_arg = Osc.Types.(Message {
   address = "/test";
   arguments = [
     Timetag Immediate;
   ];
 })
 
-let message_timetag_time_arg = Osc_types.(Message {
+let message_timetag_time_arg = Osc.Types.(Message {
   address = "/test";
   arguments = [
     Timetag (Time {seconds = 456l; fraction = 123l});
   ];
 })
 
-let message_all_args = Osc_types.(Message {
+let message_all_args = Osc.Types.(Message {
   address = "/test";
   arguments = [
     Blob "baz";
@@ -55,27 +54,27 @@ let message_all_args = Osc_types.(Message {
   ];
 })
 
-let bundle_immediate_no_packets = Osc_types.(Bundle {
+let bundle_immediate_no_packets = Osc.Types.(Bundle {
   timetag = Immediate;
   packets = [];
 })
 
-let bundle_no_packets = Osc_types.(Bundle {
+let bundle_no_packets = Osc.Types.(Bundle {
   timetag = Time {seconds = 147l; fraction = 258l};
   packets = [];
 })
 
-let bundle_one_message = Osc_types.(Bundle {
+let bundle_one_message = Osc.Types.(Bundle {
   timetag = Time {seconds = 12l; fraction = 48l};
   packets = [message_all_args];
 })
 
-let bundle_two_messages = Osc_types.(Bundle {
+let bundle_two_messages = Osc.Types.(Bundle {
   timetag = Immediate;
   packets = [message_all_args; message_empty_blob_arg];
 })
 
-let bundle_recursive = Osc_types.(Bundle {
+let bundle_recursive = Osc.Types.(Bundle {
   timetag = Time {seconds = 678l; fraction = 345l};
   packets = [message_all_args; bundle_two_messages];
 })
@@ -107,7 +106,7 @@ let test_packets_internal =
   test_packets_basic @ test_packets_extended @ test_bundles
 
 let are_arguments_equal arg1 arg2 =
-  let open Osc_types in
+  let open Osc.Types in
   match arg1, arg2 with
   | Blob a, Blob b -> a = b
   | String a, String b -> a = b
@@ -119,20 +118,20 @@ let are_arguments_equal arg1 arg2 =
   | _, _ -> false
 
 let string_of_argument = function
-  | Osc_types.Blob s -> Printf.sprintf "Blob %s" s
-  | Osc_types.String s -> Printf.sprintf "String %s" s
-  | Osc_types.Int32 i -> Printf.sprintf "Int32 %ld" i
-  | Osc_types.Float32 f -> Printf.sprintf "Float32 %f" f
-  | Osc_types.Timetag t ->
+  | Osc.Types.Blob s -> Printf.sprintf "Blob %s" s
+  | Osc.Types.String s -> Printf.sprintf "String %s" s
+  | Osc.Types.Int32 i -> Printf.sprintf "Int32 %ld" i
+  | Osc.Types.Float32 f -> Printf.sprintf "Float32 %f" f
+  | Osc.Types.Timetag t ->
     Printf.sprintf "Timetag %s"
       (match t with
-      | Osc_types.Immediate -> "Immediate"
-      | Osc_types.Time time ->
+      | Osc.Types.Immediate -> "Immediate"
+      | Osc.Types.Time time ->
         Printf.sprintf "%ld.%ld"
-          time.Osc_types.seconds time.Osc_types.fraction)
+          time.Osc.Types.seconds time.Osc.Types.fraction)
 
 let assert_messages_equal message1 message2 =
-  let open Osc.Osc_types in
+  let open Osc.Types in
   assert_equal
     ~msg:"Incorrect address"
     message1.address message2.address;
@@ -150,7 +149,7 @@ let assert_messages_equal message1 message2 =
     message2.arguments
 
 let rec assert_bundles_equal bundle1 bundle2 =
-  let open Osc.Osc_types in
+  let open Osc.Types in
   assert_equal
     ~msg:"Incorrect timetag"
     bundle1.timetag bundle2.timetag;
@@ -163,7 +162,7 @@ let rec assert_bundles_equal bundle1 bundle2 =
     bundle1.packets bundle2.packets
 
 and assert_packets_equal packet1 packet2 =
-  let open Osc.Osc_types in
+  let open Osc.Types in
   match packet1, packet2 with
   | Message message1, Message message2 ->
     assert_messages_equal message1 message2

--- a/test/core/test_string.ml
+++ b/test/core/test_string.ml
@@ -24,7 +24,7 @@ let test_message_encode_decode_suite =
   )
 
 let test_data =
-  let open Osc.Osc_types in
+  let open Osc.Types in
   [
     (* A packet which we expect to decode successfully. *)
     "message_ok",

--- a/test/interop_sclang/test_interop_sclang.ml
+++ b/test/interop_sclang/test_interop_sclang.ml
@@ -9,7 +9,7 @@ type test_config = {
 }
 
 let ping_sclang config packet =
-  let open Osc.Osc_types in
+  let open Osc.Types in
   let open Osc_unix.Udp in
   let localhost = Unix.inet_addr_of_string "127.0.0.1" in
   let ml_addr = Unix.ADDR_INET (localhost, config.ml_port) in


### PR DESCRIPTION
The internal module is still named Osc_types to avoid conflict with
the compiler-libs Types module.